### PR TITLE
Build system (bazel) setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.metadata/
+bazel-*

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,4 @@
+# alias(
+# 	name = "CubeCamera",
+# 	actual = "//CubeCamera:CubeCamera",
+# )

--- a/CubeCamera/BUILD
+++ b/CubeCamera/BUILD
@@ -1,0 +1,16 @@
+java_library(
+	name = "libcamera",
+	srcs = [
+		"src/CameraPlane.java",
+		"src/CubeStuff.java",
+		"src/Line.java",
+		"src/Vector.java",
+	]
+)
+
+java_binary(
+	name = "CubeCamera",
+	srcs = ["src/CubeCamera.java"],
+	main_class = "CubeCamera",
+	deps = ["libcamera"],
+)


### PR DESCRIPTION
This will ensure a hermetic build across different machines. It will also allows us to easily integrate GPU-accelerated modules in the future if deemed necessary.